### PR TITLE
SOAP Server with Mojo::Server::Daemon

### DIFF
--- a/examples/mojo/server.pl
+++ b/examples/mojo/server.pl
@@ -1,0 +1,149 @@
+#!/usr/bin/perl
+# Framework for a Daemon based on Mojolicious
+
+use warnings;
+use strict;
+
+my $VERSION = "0.01";
+
+use Log::Report 'mojo-example';
+
+use XML::Compile::SOAP::Daemon::Mojo;
+use XML::Compile::WSDL11;      # use WSDL version 1.1
+use XML::Compile::SOAP11;      # use SOAP version 1.1
+use XML::Compile::Schema ();
+use XML::Compile::Util qw/pack_type/;
+
+use Mojo::Log;
+use Getopt::Long   qw/:config no_ignore_case bundling/;
+use File::Basename qw/basename/;
+use HTTP::Status   qw/:constants/;
+
+my $wsdl_fn = 'web_service_desc.wsdl';
+
+my %wsdl = (
+    'http://example.domain.com/mojo-example/' => $wsdl_fn,
+);
+
+# dispatcher callback with Mojo::Log
+
+my $log = Mojo::Log->new;
+
+my %log = (
+    TRACE => sub { $log->debug(@_) },
+    ASSERT => sub { $log->error(@_) },
+    INFO => sub { $log->info(@_) },
+    NOTICE => sub { $log->info(@_) },
+    WARNING => sub { $log->warn(@_) },
+    MISTAKE => sub { $log->warn(@_) },
+    ERROR => sub { $log->error(@_) },
+    FAULT => sub { $log->error(@_) },
+    ALERT => sub { $log->warn(@_) },
+    FAILURE => sub { $log->fatal(@_) },
+    PANIC => sub { $log->fatal(@_) },
+);
+
+sub log {
+    my ($disp, $options, $reason, $message) = @_;
+    chomp(my $text = $disp->translate($options, $reason, $message))
+        or return;
+    $log{$reason}->($text);
+    1;
+}
+
+# Forward declarations
+sub do_something($$$);
+
+##
+#### MAIN
+##
+
+my $mode = 2;
+
+my $cert = "my_cert.pem";
+my $key = "my_key.pem";
+
+my %options = (
+    port => 1234,
+    host => 'localhost',
+);
+
+GetOptions
+   'v+'          => \$mode  # -v -vv -vvv
+ , 'verbose=i'   => \$mode  # --verbose=2  (0..3)
+ , 'mode=s'      => \$mode  # --mode=DEBUG (DEBUG,ASSERT,VERBOSE,NORMAL)
+
+ , 'port|p=i'    => \$options{port} # --port=444
+ , 'host|h=s'    => \$options{host} # --host=localhost
+   or error "Deamon is not started";
+
+error __x"No filenames expected on the command-line"
+    if @ARGV;
+
+my %runopt =
+  ( name        => basename($0)
+  , listen      => [
+      "https://$options{host}:$options{port}?reuse=1&cert=$cert&key=$key"
+  ],
+  , server_name => 'mojo-example',
+  );
+
+my $debug = $mode==3;
+
+# log to Mojo::Log
+dispatcher close         => 'default';
+dispatcher CALLBACK      => 'cb',
+           callback      => \&log,
+           mode          => $mode,
+           format_reason => 'IGNORE';
+
+use XML::Compile ();
+XML::Compile->addSchemaDirs("schemas/");
+XML::Compile->knownNamespace(%wsdl);
+
+my $daemon = XML::Compile::SOAP::Daemon::Mojo->new;
+my $wsdl   = XML::Compile::WSDL11->new;
+
+$wsdl->addWSDL($_) for keys %wsdl;
+
+$wsdl->namespaces->printIndex;
+
+$daemon->operationsFromWSDL
+  ( $wsdl
+  , callbacks => { 'DoUpdate' => \&do_update }
+  );
+
+# set response to http://example.domain.com/mojo-example/?wsdl
+$daemon->setWsdlResponse("schemas/$wsdl_fn");
+
+# now start the daemon to handle requests
+info "starting daemon";
+
+$daemon->run(%runopt);
+
+info "Daemon stopped";
+
+exit 0;
+
+### implement your callbacks here
+
+sub do_update($$$)
+{   my ($server, $datain, $req) = @_;
+
+    my $my_err_ns = "https://$options{host}:$options{port}/err";
+
+    if ((my $name = $datain->{Name}) ne $allowed) {
+        return
+        { Fault =>
+             { faultcode   => pack_type($my_err_ns, 'Client.Unauthorized')
+             , faultstring => "failed secure code for $name"
+             , faultactor  => MY_ROLE
+             }
+          , _RETURN_CODE => HTTP_UNAUTHORIZED # 401
+          , _RETURN_TEXT => 'Unauthorized'
+          };
+    }
+
+    # this will end-up as answer at client-side
+    return { Response => 'OK', Message => 'Completed OK' };
+}

--- a/lib/XML/Compile/SOAP/Daemon/LWPutil.pm
+++ b/lib/XML/Compile/SOAP/Daemon/LWPutil.pm
@@ -179,7 +179,7 @@ sub lwp_make_response($$$$;$)
     }
     else
     {   $s = "[$status] $body";
-        $response->header(Content_Type => 'text/plain');
+        $response->header('Content-Type' => 'text/plain');
     }
 
     $postproc->($request, $response, $status, \$s)

--- a/lib/XML/Compile/SOAP/Daemon/Mojo.pm
+++ b/lib/XML/Compile/SOAP/Daemon/Mojo.pm
@@ -1,0 +1,248 @@
+# This code is part of distribution XML-Compile-SOAP-Daemon.  Meta-POD
+# processed with OODoc into POD and HTML manual-pages.  See README.md
+# Copyright Mark Overmeer.  Licensed under the same terms as Perl itself.
+
+package XML::Compile::SOAP::Daemon::Mojo;
+package XML::Compile::SOAP::Daemon::Mojo::Log;
+
+use Mojo::Base -base;
+use Log::Report 'xml-compile-soap-daemon', import => []; # no function imports
+
+my %level = (
+    debug => \&Log::Report::trace,
+    info  => \&Log::Report::info,
+    warn  => \&Log::Report::warning,
+    error => sub { eval { Log::Report::error(@_) } },   # non-fatal Mojo::Log
+    fatal => sub { eval { Log::Report::failure(@_) } }, # non-fatal Mojo::Log
+);
+
+my $LR = 'Log::Report';
+my $msg = 'method "{reason}" not implemented';
+
+for (qw/
+    format 
+    handle
+    history
+    max_history_size
+    path
+    short
+    append
+    is_level
+/) {
+    eval "sub $_ { ${LR}::error(${LR}::__x('$msg', reason => '$_')) }"
+}
+
+for (qw/
+    error 
+    debug
+    fatal
+    info
+    warn
+/) {
+    eval "sub $_ { my \$self = shift; \$level{$_}->(join \"\\n\", \@_); \$self }"
+}
+
+sub level {
+    my ($self, $level) = @_;
+    return $level 
+        ? ($self->{level} = $level)
+        : $self->{level};
+}
+
+1;
+package XML::Compile::SOAP::Daemon::Mojo;
+
+use warnings;
+use strict;
+
+use parent 'XML::Compile::SOAP::Daemon';
+
+use Log::Report qw/xml-compile-soap-daemon/;
+use Mojo::Server::Daemon;
+use XML::Compile::SOAP::Daemon::MojoUtil;
+
+=chapter NAME
+XML::Compile::SOAP::Daemon::Mojo - SOAP server based on Mojo::Server::Daemon
+
+=chapter SYNOPSIS
+ #### have a look in the examples directory!
+ use XML::Compile::SOAP::Daemon::Mojo;
+ use XML::Compile::SOAP11;
+ use XML::Compile::SOAP::WSA;  # optional
+
+ my $daemon  = XML::Compile::SOAP::Daemon::Mojo->new;
+
+ # daemon definitions from WSDL
+ my $wsdl    = XML::Compile::WSDL11->new(...);
+ $wsdl->importDefinitions(...); # more schemas
+ $daemon->operationsFromWSDL($wsdl, callbacks => ...);
+
+ # daemon definitions added manually (when no WSDL)
+ my $soap11  = XML::Compile::SOAP11::Server->new(schemas => $wsdl->schemas);
+ my $handler = $soap11->compileHandler(...);
+ $daemon->addHandler('getInfo', $soap11, $handler);
+
+ # see what is defined:
+ $daemon->printIndex;
+
+ # finally, run the server.  This never returns.
+ $daemon->run(@daemon_options);
+ 
+=chapter DESCRIPTION
+This module handles the exchange of SOAP messages over HTTP with
+M<Mojo::Server::Daemon> as daemon implementation based on the M<Mojolicious>
+framework.
+
+We use M<HTTP::Daemon> as HTTP-connection implementation. The
+M<HTTP::Request> and M<HTTP::Response> objects (provided
+by C<HTTP-Message>) are handled via functions provided by
+M<XML::Compile::SOAP::Daemon::LWPutil>.
+
+This abstraction level of the object (code in this pm file) is not
+concerned with parsing or composing XML, but only worries about the
+HTTP transport specifics of SOAP messages.  The processing of the SOAP
+message is handled by the M<XML::Compile::SOAP::Daemon> base-class.
+
+The server is as flexible as possible: accept M-POST (HTTP Extension
+Framework) and POST (standard HTTP) for any message.  It can be used
+for any SOAP1.1 and SOAP1.2 mixture.  Although SOAP1.2 itself is
+not implemented yet.
+
+=chapter METHODS
+
+=c_method new %options
+Create the server handler, which extends some class which implements
+a M<Net::Server> daemon.
+
+As %options, you can pass everything accepted by M<Any::Daemon::new()>,
+like C<pid_file>, C<user>, C<group>, and C<workdir>,
+=cut
+
+sub new($%)
+{   my ($class, %args) = @_;
+    my $server_name = delete $args{server_name} || 'soap server';
+    my $self = $class->SUPER::new(%args);
+    $self->server_name($server_name);
+    return $self;
+}
+
+sub server_name($;$)
+{   my ($self, $server_name) = @_;
+    return $server_name 
+        ? ($self->{server_name} = $server_name)
+        : $self->{server_name};
+}
+
+=method setWsdlResponse [$wdslfile|$response] [$mime_type]
+
+Set response for WSDL:
+
+  $scheme://$host:$port?wsdl
+
+Takes either a prepaired response object M<Mojo::Message::Response>, or
+C<$wsdlfile> and optionally C<$mime_type>.
+
+Examples:
+
+  $daemon->setWsdlResponse($res);
+  $daemon->setWsdlResponse("soap_example.wsdl");
+  $daemon->setWsdlResponse("soap_example.wsdl", "application/xml");
+=cut
+
+sub setWsdlResponse($;$)
+{   my ($self, $fn, $ft) = @_;
+    trace "setting wsdl response to $fn";
+    mojo_wsdl_response($fn, $ft);
+}
+
+#-----------------------
+=section Running the server
+
+=method run %options
+
+=option  server_name   STRING
+=default server_name   C<undef>
+
+=option  listen ARRAYREF
+=default listen C<undef>
+
+List of locations to listen on, see L<Mojo::Server::Daemon/listen>.
+
+=option  postprocess CODE
+=default postprocess C<undef>
+
+See the section about this option in the DETAILS chapter of the
+M<XML::Compile::SOAP::Daemon::MojoUtil> manual-page.
+=cut
+
+sub _run($)
+{   my ($self, $args) = @_;
+
+    mojo_add_header(Server => $self->server_name($args->{server_name}));
+
+    my $postproc = $args->{postprocess};
+
+    my $daemon = Mojo::Server::Daemon->new(listen => $args->{listen});
+
+    # couple Mojo::Log to Log::Report
+    $daemon->app->{log} = XML::Compile::SOAP::Daemon::Mojo::Log->new;
+
+    $daemon->unsubscribe('request')->on(request => sub {
+        my ($daemon, $tx) = @_;
+
+        info __x"new client {remote}", remote => $tx->remote_address;
+
+        # prepare for processing
+
+        my $handler = sub { $self->process(@_) };
+        my $req = $tx->req->default_charset('utf-8');
+        my $res = mojo_run_request($req, $handler, $postproc);
+
+        # build response
+
+        $tx->res($res);
+        $tx->resume;
+    });
+
+    $daemon->run;
+}
+
+sub url() { "url replacement not yet implemented" }
+sub product_tokens() { shift->{prop}{name} } # TODO what?
+
+#-----------------------------
+
+=chapter DETAILS
+
+=section Mojo with SSL
+
+Accepts standard Mojo SSL options including C<cert>, C<key> and C<ca>, see 
+L<Mojo::Server::Daemon/listen>.
+
+  use Log::Report;
+  use XML::Compile::SOAP::Daemon::Mojo;
+  use XML::Compile::WSDL11;
+
+  my $daemon = XML::Compile::SOAP::Daemon::Mojo->new;
+  my $wsdl   = XML::Compile::WSDL11->new($wsdl);
+
+  $daemon->operationsFromWSDL($wsdl, callbacks => \%handlers);
+
+  requrie Net::SSLeay;
+  my $verify = Net::SSLeay::VERIFY_PEER() 
+             | Net::SSLeay::VERIFY_FAIL_IF_NO_PEER_CERT();
+
+  my $listen = [
+    "https://.*:443?reuse=1&cert=$cert&key=$key&ca=$ca&verify=$verify"
+  ];
+
+  $daemon->run
+   ( name        => basename($0)
+   , server_name => 'Custom SOAP Server',
+   , listen      => $listen
+   , postprocess => \&postprocess
+   );
+=cut
+
+1;
+

--- a/lib/XML/Compile/SOAP/Daemon/MojoUtil.pm
+++ b/lib/XML/Compile/SOAP/Daemon/MojoUtil.pm
@@ -1,0 +1,251 @@
+# This code is part of distribution XML-Compile-SOAP-Daemon.  Meta-POD
+# processed with OODoc into POD and HTML manual-pages.  See README.md
+# Copyright Mark Overmeer.  Licensed under the same terms as Perl itself.
+
+package XML::Compile::SOAP::Daemon::MojoUtil;
+
+use parent 'Exporter';
+
+use warnings;
+use strict;
+
+=chapter NAME
+
+XML::Compile::SOAP::Daemon::MojoUtil - Mojo helper routines
+
+=chapter SYNOPSIS
+  # used by ::Daemon::Mojo
+
+=chapter DESCRIPTION
+=cut
+
+our @EXPORT = qw(
+    mojo_action_from_header
+    mojo_add_header
+    mojo_make_response
+    mojo_run_request
+    mojo_wsdl_response
+);
+
+use Log::Report 'xml-compile-soap-daemon';
+use XML::Compile::SOAP::Util qw/:daemon/; # MSEXT
+use List::Util qw/any pairs first/;
+use HTTP::Status qw/RC_OK RC_METHOD_NOT_ALLOWED RC_NOT_ACCEPTABLE/;
+
+sub mojo_add_header($$@);
+sub mojo_run_request($$;$);
+sub mojo_make_response($$$$;$);
+sub mojo_action_from_header($);
+
+=chapter FUNCTIONS
+
+=function mojo_add_header $field, $content, ...
+=cut
+
+our @default_headers;
+BEGIN
+{   no strict 'refs';
+    @default_headers = (
+        map {
+            eval "require $_";
+            my $version = ${"${_}::VERSION"} || 'undef';
+            (my $field = "X-${_}-Version") =~ s/\:\:/-/g;
+            $field => $version
+        } qw/
+            XML::Compile 
+            XML::Compile::SOAP
+            XML::Compile::SOAP::Daemon 
+            XML::LibXML 
+            Mojolicious
+        /
+    );
+}
+
+sub mojo_add_header($$@) { push @default_headers, @_ }
+
+=function mojo_make_response $req, $status, $msg, $body, [$postproc]
+
+Make a M<Mojo::Message::Response> matching given params, and optionally make 
+callback to C<$postproc> along with given M<Mojo::Message::Request> object.
+=cut
+
+sub mojo_make_response($$$$;$)
+{   my ($req, $status, $msg, $body, $postproc) = @_;
+
+    my $res = Mojo::Message::Response->new;
+    $res->code($status);
+    $res->message($msg);
+    $res->headers->add(@$_) for pairs @default_headers; 
+
+    my $s;
+    if(UNIVERSAL::isa($body, 'XML::LibXML::Document'))
+    {   $s = $body->toString($status == RC_OK ? 0 : 1);
+        $res->headers->content_type('text/xml; charset=utf-8');
+    }
+    else
+    {   $s = "[$status] $body";
+        $res->headers->content_type('text/plain');
+    }
+
+    # do any post processing
+    $postproc->($req, $res, $status, \$s) if $postproc;
+
+    $res->body($s);
+
+    if(substr($req->method, 0, 2) eq 'M-')
+    {   # HTTP extension framework.  More needed?
+        $res->headers->add(Ext => '');
+    }
+
+    return $res;
+}
+
+=function mojo_action_from_header $req
+
+Collect the soap action URI from the request, with C<undef> on failure.
+
+Officially, the "SOAPAction" has no other purpose than the ability to
+route messages over HTTP: it should not be linked to the portname of
+the message (although it often can).
+=cut
+
+sub mojo_action_from_header($)
+{   my ($req) = @_;
+
+    my $action;
+    if($req->method eq 'POST')
+    {   $action = $req->headers->header('SOAPAction');
+    }
+    elsif($req->method eq 'M-POST')
+    {   # Microsofts HTTP Extension Framework
+        my $http_ext_id = '"' . MSEXT . '"';
+        my $man = first { m/\Q$http_ext_id\E/ } $req->headers->header('Man')//'';
+        defined $man or return undef;
+
+        $man =~ m/\;\s*ns\=(\d+)/ or return undef;
+        $action = $req->headers->header("$1-SOAPAction");
+    }
+
+    defined $action or return;
+
+    $action =~ s/["'\s]//g;  # often wrong blanks and quotes
+    return $action;
+}
+
+=function mojo_wsdl_response [$wsdlfile|$response] [$mime_type]
+
+Sets WSDL query responses. Response is M<Mojo::Message::Response> object.
+
+Takes either an existing response object or a C<$wsdlfile> and optional 
+C<$mime_type> from which to build a response.
+=cut
+
+my $wsdl_response;
+sub mojo_wsdl_response(;$$)
+{   @_ or return $wsdl_response;
+
+    my ($fn, $mime_type) = @_;
+
+    return ($wsdl_response = $fn) unless $fn && !ref $fn;
+
+    local *SRC;
+    open SRC, '<:raw', $fn
+        or fault __x"cannot read wsdl file {file}", file => $fn;
+    local $/;
+    my $spec = <SRC>;
+    close SRC;
+
+    $mime_type ||= 'application/wsdl+xml';
+    my $res = Mojo::Message::Response->new;
+    $res->code(RC_OK);
+    $res->message("WSDL specification");
+    $res->headers->add(@$_) for pairs @default_headers;
+    $res->headers->content_type("$mime_type; charset=utf-8");
+    $res->body($spec);
+    return ($wsdl_response = $res);
+}
+    
+=function mojo_run_request $req, $handler, [$postproc]
+
+Handle one $req (M<Mojo::Message::Request> object).
+
+Call the C<$handler> callback with request, xml to process and action when a
+valid looking request was found.
+
+Call the C<$postproc> callback with the M<Mojo::Message::Response> object, once
+a response has been built.
+=cut
+
+sub mojo_run_request($$;$)
+{   my ($req, $handler, $postproc) = @_;
+
+    # check
+
+    if ($wsdl_response
+        && $req->method eq 'GET' 
+        && any { uc($_->[0]) eq 'WSDL' } pairs @{$req->url->query->pairs})
+    {   # request for WSDL
+        return $wsdl_response;
+    }
+
+    if($req->method !~ m/^(?:M-)?POST/ )
+    {   # bad HTTP method
+        return mojo_make_response(
+            $req, 
+            RC_METHOD_NOT_ALLOWED, 
+            'only POST or M-POST', 
+            "attempt to connect via ".$req->method,
+        );
+    }
+
+    my $media = $req->headers->content_type || 'text/plain';
+
+    if ($media !~ m{/xml(?:;|$)}i)
+    {   # bad Content-Type
+        return mojo_make_response(
+            $req, 
+            RC_NOT_ACCEPTABLE, 
+            'required is XML', 
+            "content-type seems to be $media, must be some XML",
+        );
+    }
+
+    my $action = mojo_action_from_header($req);
+    my $xmlin  = $req->text;
+
+    # process 
+
+    my ($status, $msg, $xml) = eval { $handler->(\$xmlin, $req, $action); }; 
+    info __x"connection ended with force; {error}", error => $@ if $@;
+
+    # return response
+
+    return mojo_make_response($req, $status, $msg, $xml, $postproc);
+}
+
+#------------------------------
+=chapter DETAILS
+
+=section Postprocessing responses
+
+The C<Mojolicious> based daemons provide a C<$postprocess> option to their 
+C<run()> methods.  The parameter is a CODE reference.
+
+When defined, the CODE is called when the response message is ready
+to be returned to the client:
+
+  $code->($req, $res, $status, \$body)
+
+The source C<$req> is passed as first parameter. The C<$res>
+is an M<Mojo::Message::Response> object, with all headers but without the body.
+The C<$status> is the result code of the handler. A value of 200 (C<HTTP_OK> 
+from C<HTTP::Status>) indicates successful processing of the request. When the 
+status is not HTTP_OK you may skip the postprocessing.
+
+The C<$body> are the bytes which will be added as body to the response
+after this postprocessing has been done. You may change the body.
+
+=cut
+
+1;
+

--- a/t/01use.t
+++ b/t/01use.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 3;
+use Test::More tests => 4;
 
 # The versions of the following packages are reported to help understanding
 # the environment in which the tests are run.  This is certainly not a
@@ -46,6 +46,9 @@ my $has_lwp = $@ ? 0 : 1;
 eval "require CGI";
 my $has_cgi = $@ ? 0 : 1;
 
+eval "require Mojolicious";
+my $has_mojo = $@ ? 0 : 1;
+
 if($has_net_server && $has_lwp)
 {   require_ok('XML::Compile::SOAP::Daemon::NetServer');
 }
@@ -58,4 +61,11 @@ if($has_cgi)
 }
 else
 {   ok(1, 'CGI not installed');
+}
+
+if($has_mojo)
+{   require_ok('XML::Compile::SOAP::Daemon::Mojo');
+}
+else
+{   ok(1, 'Mojolicious not installed');
 }

--- a/t/fault_mojo.t
+++ b/t/fault_mojo.t
@@ -1,0 +1,206 @@
+#!/usr/bin/env perl
+# Attempt to produce all errors when running Mojo::Server::Daemon
+
+use warnings;
+use strict;
+
+use Test::More;
+use XML::Compile::WSDL11;
+use XML::Compile::SOAP11;
+use XML::Compile::SOAP::Util ':soap11';
+
+use HTTP::Request;
+
+BEGIN
+{   eval "require Mojolicious";
+    my $has_mojo = $@ ? 0 : 1;
+
+    eval "require LWP";
+    my $has_lwp = $@ ? 0 : 1;
+
+    $has_mojo && $has_lwp
+        or plan skip_all => "Mojolicious and LWP are required for these tests";
+
+    $^O ne 'MSWin32'
+        or plan skip_all => "Please contribute by porting tests to Windows";
+}
+
+use constant
+  { SERVERHOST => 'localhost'
+  , SERVERPORT => 8876
+  };
+
+plan tests => 18;
+
+require_ok('XML::Compile::SOAP::Daemon::Mojo');
+require_ok('LWP::UserAgent');
+
+my $daemon = XML::Compile::SOAP::Daemon::Mojo->new;
+
+my $soapenv = SOAP11ENV;
+my $uri     = "http://".SERVERHOST.":".SERVERPORT;
+my $listen  = "http://127.0.0.1:".SERVERPORT;
+
+my $daemon_pid;
+unless($daemon_pid = fork())
+{   # Child
+
+# test-script debugging
+# use Log::Report mode => 3;
+
+    $daemon->run
+     ( name     => 'Test server'
+     , listen   => [ $listen ],
+     );
+     exit;
+}
+
+unless($daemon_pid)
+{   plan skip_all => "Unable to start daemon";
+}
+
+sub stop_daemon()
+{  defined $daemon_pid or return;
+   ok(1, "Stopping daemon $daemon_pid");
+   kill TERM => $daemon_pid;
+   sleep(1);
+}
+
+END { stop_daemon }
+
+sub compare_answer($$$)
+{   my ($answer, $expected, $text) = @_;
+    isa_ok($answer, 'HTTP::Response');
+    UNIVERSAL::isa($answer, 'HTTP::Response') or return;
+
+	# error not always the same for various libxml versions
+	my $content = $answer->decoded_content;
+	$content =~ s/( error\:) .*\z/$1 LIBXML-ERROR\n/s;
+
+    my $h = $answer->headers;
+    my $a = join "\n"
+     , $answer->code
+     , $answer->message
+     , $answer->content_type, ''
+     , $content;
+    $a =~ s/\s*\z/\n/;
+
+    is($a, $expected, $text);
+}
+
+###
+### BEGIN
+###
+
+ok(1, "Started daemon $daemon_pid");
+isa_ok($daemon, 'XML::Compile::SOAP::Daemon::Mojo');
+
+my $ua = LWP::UserAgent->new;
+isa_ok($ua, 'LWP::UserAgent');
+
+### GET request
+
+my $req1 = HTTP::Request->new(GET => $uri);
+my $ans1 = $ua->request($req1);
+
+compare_answer($ans1, <<__EXPECTED, 'not POST');
+405
+only POST or M-POST
+text/plain
+
+[405] attempt to connect via GET
+__EXPECTED
+
+### Non XML POST request
+
+my $req2 = HTTP::Request->new(POST => $uri);
+my $ans2 = $ua->request($req2);
+
+compare_answer($ans2, <<__EXPECTED, 'not XML');
+406
+required is XML
+text/plain
+
+[406] content-type seems to be text/plain, must be some XML
+__EXPECTED
+
+### XML parsing fails
+
+my $req4 = HTTP::Request->new(POST => $uri);
+$req4->header(Content_Type => 'text/xml');
+$req4->header(soapAction => '');
+$req4->content("<bad-xml>");
+my $ans4 = $ua->request($req4);
+
+compare_answer($ans4, <<__EXPECTED, 'parsing error');
+422
+XML syntax error
+text/plain
+
+[422] The XML cannot be parsed: error: LIBXML-ERROR
+__EXPECTED
+
+### Not SOAP Envelope
+
+my $req5 = HTTP::Request->new(POST => $uri);
+$req5->header(Content_Type => 'text/xml');
+$req5->header(soapAction => '');
+$req5->content("<not-soap></not-soap>");
+my $ans5 = $ua->request($req5);
+
+compare_answer($ans5, <<__EXPECTED, 'no soap envelope');
+403
+message not SOAP
+text/plain
+
+[403] The message was XML, but not SOAP; not an Envelope but `not-soap'
+__EXPECTED
+
+### Unknown SOAP Envelope
+
+my $req6 = HTTP::Request->new(POST => $uri);
+$req6->header(Content_Type => 'text/xml');
+$req6->header(soapAction => '');
+$req6->content('<me:Envelope xmlns:me="xx"></me:Envelope>');
+my $ans6 = $ua->request($req6);
+
+compare_answer($ans6, <<__EXPECTED, 'unknown soap envelope');
+501
+SOAP version not supported
+text/plain
+
+[501] The soap version `xx' is not supported
+__EXPECTED
+
+
+### Message not found
+
+my $req7 = HTTP::Request->new(POST => $uri);
+$req7->header(Content_Type => 'text/xml');
+$req7->header(soapAction => '');
+$req7->content( <<_NO_SUCH);
+<me:Envelope xmlns:me="$soapenv">
+  <me:Body>
+    <me:something />
+  </me:Body>
+</me:Envelope>
+_NO_SUCH
+my $ans7 = $ua->request($req7);
+
+compare_answer($ans7, <<__EXPECTED, 'message not found');
+404
+message not recognized
+text/xml
+charset=utf-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body>
+    <SOAP-ENV:Fault>
+      <faultcode>SOAP-ENV:Server.notRecognized</faultcode>
+      <faultstring>SOAP11 there are no handlers available, so also not for {http://schemas.xmlsoap.org/soap/envelope/}something</faultstring>
+      <faultactor>http://schemas.xmlsoap.org/soap/actor/next</faultactor>
+    </SOAP-ENV:Fault>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+__EXPECTED


### PR DESCRIPTION
Hi, 

This is a pull request for a `Mojo` compatible `XML::Compile::SOAP::Daemon`. I'm keen to get something like this accepted, and am happy to take on-board any suggestions, or requirements you may have.

I don't think this is the final pull request - at very least the POD needs some work - but I would like to get the ball rolling and get your feedback on the approach I've taken. 

I've also snuck in one fix - I think - for what appears to be a typo in `lib/XML/Compile/SOAP/Daemon/LWPutil.pm`.

I've opted to use `Mojo::Server::Daemon` rather than mess around with my own HTTP Server implementation in `Mojo`, and opted to stick with the `Mojo` implementations of the Request and Response objects, which meant reimplementing a fair bit of the LWPUtil class.

I've also opted to mostly expose the `Mojo::Server::Daemon` interface for defining a listener as is.

Looking forward to hearing back from you. 

P.S. I'm also interested in having a re-look at the client module.
